### PR TITLE
Bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-redis = "0.13.0"
-rand = "0.7.2"
+redis = "0.20.0"
+rand = "0.8.3"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -53,7 +53,7 @@ pub fn main() {
                 }
                 let val: i32 = redis::cmd("GET").arg(incr_key).query(&mut con).unwrap_or(0);
 
-                let n = rng.gen_range(0, 5);
+                let n = rng.gen_range(0..5);
                 thread::sleep(Duration::from_millis(n));
 
                 redis::cmd("SET")

--- a/src/redlock.rs
+++ b/src/redlock.rs
@@ -149,7 +149,7 @@ impl RedLock {
                 }
             }
 
-            let n = rng.gen_range(0, self.retry_delay);
+            let n = rng.gen_range(0..self.retry_delay);
             sleep(Duration::from_millis(u64::from(n)));
         }
         None


### PR DESCRIPTION
The signature of `gen_range` changed from min inclusive to max exclusive to expecting a range. The behavior should have been preserved though. 