### PR TITLE
Handle overflow error for low ttls values

### DIFF
--- a/src/redlock.rs
+++ b/src/redlock.rs
@@ -52,13 +52,16 @@ impl Drop for RedLockGuard<'_> {
 }
 
 fn get_validity_time(ttl: usize, drift: usize, elapsed: Duration) -> usize {
-    ttl
-        - drift
-        - elapsed.as_secs() as usize * 1000
-        - elapsed.subsec_nanos() as usize / 1_000_000
+    let validity_time = ttl as i64
+        - drift as i64
+        - elapsed.as_secs() as i64 * 1000
+        - elapsed.subsec_nanos() as i64 / 1_000_000;
+
+    if validity_time < 0 {
+        return 0_usize;
+    }
+    validity_time as usize
 }
-
-
 
 
 impl RedLock {
@@ -426,6 +429,4 @@ mod tests {
     fn test_validity_time_overflow() {
         get_validity_time(1, 15, Duration::from_millis(15));
     }
-
-
 }

--- a/src/redlock.rs
+++ b/src/redlock.rs
@@ -63,7 +63,6 @@ fn get_validity_time(ttl: usize, drift: usize, elapsed: Duration) -> usize {
     validity_time as usize
 }
 
-
 impl RedLock {
     /// Create a new lock manager instance, defined by the given Redis connection uris.
     /// Quorum is defined to be N/2+1, with N being the number of given Redis instances.


### PR DESCRIPTION
Solves #20 

I want to use a sub 50ms `ttls` for my lock, but that's not currently always possible. The closer to zero, the more likely the current logic is to panicking. 

I've added a failing test in the first commit to demonstrate the issue.

Quick disclaimer: I'm new to rust, so if there's a better way to do this please let me know. I'd like to know :slightly_smiling_face: 