### PR TITLE
fix: RUSTSEC-2020-0071: Potential segfault in the time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2021"
 redis = "0.23.0"
 rand = "0.8.5"
 tokio = { version = "1.27.0", features = ["rt"], optional = true }
+chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 
 [features]
 default = []


### PR DESCRIPTION
addresses https://github.com/badboy/redlock-rs/issues/28